### PR TITLE
fix: buildable plugin, JSON output, first feature export

### DIFF
--- a/plugin/CadQaPlugin.csproj
+++ b/plugin/CadQaPlugin.csproj
@@ -5,9 +5,15 @@
     <Platforms>x64</Platforms>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="acdbmgd"        HintPath="$(ACADSDK)\acdbmgd.dll"        Private="false" />
-    <Reference Include="acmgd"          HintPath="$(ACADSDK)\acmgd.dll"          Private="false" />
-    <Reference Include="ManagedMapApi"  HintPath="$(ACADSDK)\ManagedMapApi.dll"  Private="false" />
+    <Reference Include="acdbmgd" HintPath="$(ACADSDK)\acdbmgd.dll" Private="false" />
+    <Reference Include="acmgd" HintPath="$(ACADSDK)\acmgd.dll" Private="false" />
+    <Reference Include="ManagedMapApi" HintPath="$(ACADSDK)\ManagedMapApi.dll" Private="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\rules\*.cs" Link="Rules\%(Filename)%(Extension)" />
+    <Compile Include="..\export\*.cs" Link="Export\%(Filename)%(Extension)" />
   </ItemGroup>
 </Project>

--- a/plugin/QaChecker.cs
+++ b/plugin/QaChecker.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Text.Json;
+using CadQa.Export;
 using Autodesk.AutoCAD.ApplicationServices;
 using Autodesk.AutoCAD.DatabaseServices;
 using Autodesk.AutoCAD.Runtime;
@@ -27,6 +28,9 @@ namespace CadQaPlugin
             var issues = rules
                 .SelectMany(r => r.Evaluate(db, tr))
                 .ToList();
+
+            var textCsv = $"{db.Filename}.text.csv";
+            ExportFeatures.DumpText(db, tr, textCsv);
 
             var jsonPath = $"{db.Filename}.qa.json";
             var json = JsonSerializer.Serialize(


### PR DESCRIPTION
## Summary
- update `CadQaPlugin.csproj` to include rule and export sources
- run QA checks and dump features

## Testing
- `dotnet restore plugin/CadQaPlugin.sln`
- `dotnet build plugin/CadQaPlugin.sln` *(fails: Autodesk references missing)*
- `dotnet format plugin/CadQaPlugin.sln --verify-no-changes`

------
https://chatgpt.com/codex/tasks/task_e_68782cf172188322a4a37f43686959ac