### PR TITLE
fix: resolve CS1705 & CS0246 (legacy DLLs + Json 6.x)

### DIFF
--- a/plugin/CadQaPlugin.csproj
+++ b/plugin/CadQaPlugin.csproj
@@ -7,15 +7,21 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="acdbmgd"       HintPath="$(ACADSDK)\acdbmgd.dll"       Private="false" />
-    <Reference Include="acmgd"         HintPath="$(ACADSDK)\acmgd.dll"         Private="false" />
-    <Reference Include="ManagedMapApi" HintPath="$(ACADSDK)\ManagedMapApi.dll" Private="false" />
+    <Reference Include="acdbmgd"
+               HintPath="$(ACADSDK)\Managed\Legacy\Acdbmgd.dll"
+               Private="false" />
+    <Reference Include="acmgd"
+               HintPath="$(ACADSDK)\Managed\Legacy\Acmgd.dll"
+               Private="false" />
+    <Reference Include="ManagedMapApi"
+               HintPath="$(ACADSDK)\Managed\Legacy\ManagedMapApi.dll"
+               Private="false" />
 
     <!-- include rule and exporter source files -->
     <Compile Include="..\rules\**\*.cs" />
     <Compile Include="..\export\**\*.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="7.0.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.20" />
   </ItemGroup>
 </Project>

--- a/rules/QaIssue.cs
+++ b/rules/QaIssue.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System;
 using Autodesk.AutoCAD.DatabaseServices;
 


### PR DESCRIPTION
## Summary
- update AutoCAD reference paths to Legacy net48
- switch System.Text.Json package to 6.0.20
- enable nullable in QaIssue

## Testing
- `dotnet restore plugin/CadQaPlugin.csproj --no-cache`
- `dotnet format plugin/CadQaPlugin.csproj --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687900726edc83229c4655cc21d9e91d