### PR TITLE
Fix System.Text.Json conflict

### DIFF
--- a/plugin/CadQaPlugin.csproj
+++ b/plugin/CadQaPlugin.csproj
@@ -27,6 +27,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
-    <PackageReference Include="System.Text.Json" Version="6.0.20" />
+    <!-- align with AutoCAD 2025's .NET 8 assemblies -->
+    <PackageReference Include="System.Text.Json" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- bring System.Text.Json package up to 8.0.0 for AutoCAD 2025 compatibility

## Testing
- `dotnet build CadQaPlugin.csproj -c Release` *(fails: Autodesk references not found)*

------
https://chatgpt.com/codex/tasks/task_e_68791582bb3c8322afb7246de84d729f