### PR TITLE
feat: add ML training notebook, sample feature CSVs, and CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,25 @@
+name: Build plugin
+
+on:
+  push:
+    branches: [ main, feat/** ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+      ACADSDK: ${{ secrets.ACADSDK }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore and build
+        run: dotnet build plugin/CadQaPlugin.csproj -c Release
+      - name: Upload plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: CadQaPlugin
+          path: |
+            plugin/bin/Release/net8.0-windows/CadQaPlugin.dll

--- a/ml/data/raw/sample1.features.csv
+++ b/ml/data/raw/sample1.features.csv
@@ -1,0 +1,5 @@
+Handle,ObjType,TextString,Layer,TextHeight
+1,DBText,"CL 100 PVC",L-ANNO,0.08
+2,MText,"EXISTING HYDRANT",L-SYMB,0.1
+3,DBText,"MH-01",L-ANNO,0.08
+4,MText,"VALVE",L-MECH,0.1

--- a/ml/data/raw/sample2.features.csv
+++ b/ml/data/raw/sample2.features.csv
@@ -1,0 +1,5 @@
+Handle,ObjType,TextString,Layer,TextHeight
+1,MText,"HYDRANT",L-SYMB,0.1
+2,DBText,"VALVE",L-MECH,0.08
+3,DBText,"DRAIN",L-UTIL,0.08
+4,MText,"MANHOLE",L-MECH,0.1

--- a/ml/data/raw/sample3.features.csv
+++ b/ml/data/raw/sample3.features.csv
@@ -1,0 +1,5 @@
+Handle,ObjType,TextString,Layer,TextHeight
+1,DBText,"GATE VALVE",L-MECH,0.09
+2,MText,"FIRE HYDRANT",L-SYMB,0.12
+3,DBText,"CATCH BASIN",L-UTIL,0.08
+4,MText,"DRAIN",L-UTIL,0.1

--- a/ml/model.ipynb
+++ b/ml/model.ipynb
@@ -4,7 +4,71 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To be filled"
+    "# Layer Classification Model\n",
+    "This notebook loads feature CSVs generated from CAD drawings, trains a simple classifier to predict the appropriate layer for text entities based on their properties, and saves the trained model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import glob\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "# Load all feature CSVs from data/raw\n",
+    "data_dir = Path('ml/data/raw')\n",
+    "csv_files = list(data_dir.glob('*.features.csv'))\n",
+    "frames = []\n",
+    "for f in csv_files:\n",
+    "    df = pd.read_csv(f)\n",
+    "    df['source_file'] = f.name\n",
+    "    frames.append(df)\n",
+    "features = pd.concat(frames, ignore_index=True)\n",
+    "features.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example preprocessing: use simple heuristics for demo\n",
+    "# Here we will treat 'TextString' as the only feature and the target is 'Layer'\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.feature_extraction.text import TfidfVectorizer\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.metrics import classification_report\n",
+    "\n",
+    "X = features['TextString']\n",
+    "y = features['Layer']\n",
+    "\n",
+    "model = Pipeline([\n",
+    "    ('tfidf', TfidfVectorizer()),\n",
+    "    ('clf', LogisticRegression(max_iter=1000))\n",
+    "])\n",
+    "\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+    "model.fit(X_train, y_train)\n",
+    "preds = model.predict(X_test)\n",
+    "print(classification_report(y_test, preds))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save the trained model\n",
+    "import joblib\n",
+    "import os\n",
+    "os.makedirs('ml/artifacts', exist_ok=True)\n",
+    "joblib.dump(model, 'ml/artifacts/layer_clf.pkl')\n",
+    "print('Model saved to ml/artifacts/layer_clf.pkl')\n"
    ]
   }
  ],
@@ -20,5 +84,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
This PR introduces three main improvements:

* **Sample feature CSV files**: Added `sample1.features.csv`, `sample2.features.csv`, and `sample3.features.csv` under `ml/data/raw/`. These serve as example datasets for model training.
* **Training notebook**: Added `ml/model.ipynb`, a Jupyter notebook that loads the feature CSVs, trains a TF‑IDF + logistic regression model to classify text features into layers, and saves the trained model to `ml/artifacts/layer_clf.pkl`.
* **GitHub Actions build workflow**: Added `.github/workflows/build.yml` to automatically restore and build the plugin on each commit and upload the resulting `CadQaPlugin.dll` as an artifact.

Additional changes include updates to `QaChecker.cs` to serialize issues using a simple DTO to avoid AutoCAD object serialization errors, and ensuring `ExportFeatures.DumpText` outputs `.features.csv` during audits.

These changes provide a foundation for integrating machine learning into the QA workflow and enable continuous integration for the plugin.