### PR TITLE
Ignore numeric-only text in ML workflow

### DIFF
--- a/export/ExportFeatures.cs
+++ b/export/ExportFeatures.cs
@@ -28,16 +28,34 @@ namespace CadQa.Export
                 switch (ent)
                 {
                     case DBText t:
+                        var txt = t.TextString;
+                        if (IsMostlyNumeric(txt))
+                            continue;
                         sw.WriteLine(
-                            $"{id.Handle},{nameof(DBText)},\"{t.TextString}\",{t.Layer},{t.Height}");
+                            $"{id.Handle},{nameof(DBText)},\"{txt}\",{t.Layer},{t.Height}");
                         break;
 
                     case MText m:
+                        var txt = m.Text;
+                        if (IsMostlyNumeric(txt))
+                            continue;
                         sw.WriteLine(
-                            $"{id.Handle},{nameof(MText)},\"{m.Text}\",{m.Layer},{m.TextHeight}");
+                            $"{id.Handle},{nameof(MText)},\"{txt}\",{m.Layer},{m.TextHeight}");
                         break;
                 }
             }
+        }
+
+        static bool IsMostlyNumeric(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return true;
+            int digit = 0, alpha = 0;
+            foreach (char c in s)
+            {
+                if (char.IsDigit(c)) digit++;
+                else if (char.IsLetter(c)) alpha++;
+            }
+            return digit > 0 && alpha == 0;
         }
     }
 }

--- a/plugin/QaChecker.cs
+++ b/plugin/QaChecker.cs
@@ -47,10 +47,18 @@ namespace CadQaPlugin
                     continue;
 
                 if (ent is DBText t && !string.IsNullOrWhiteSpace(t.TextString))
-                    texts.Add(t.TextString);
+                {
+                    var txt = t.TextString;
+                    if (!IsMostlyNumeric(txt))
+                        texts.Add(txt);
+                }
 
                 else if (ent is MText m && !string.IsNullOrWhiteSpace(m.Text))
-                    texts.Add(m.Text);
+                {
+                    var txt = m.Text;
+                    if (!IsMostlyNumeric(txt))
+                        texts.Add(txt);
+                }
             }
 
             // 4 machine-learning suggestions
@@ -96,6 +104,18 @@ namespace CadQaPlugin
                 JsonSerializer.Serialize(simple, new JsonSerializerOptions { WriteIndented = true }));
 
             doc.Editor.WriteMessage($"\nQA issues found: {issues.Count}");
+        }
+
+        static bool IsMostlyNumeric(string s)
+        {
+            if (string.IsNullOrWhiteSpace(s)) return true;
+            int digit = 0, alpha = 0;
+            foreach (char c in s)
+            {
+                if (char.IsDigit(c)) digit++;
+                else if (char.IsLetter(c)) alpha++;
+            }
+            return digit > 0 && alpha == 0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- filter DBText/MText features so pure numbers don't create rows
- skip numeric-only annotation strings during ML prediction
- add helper `IsMostlyNumeric` in both components

## Testing
- `dotnet build -c Release` *(fails: AutoCAD assemblies not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e975dbb788322804d0965b92d5f8c