### PR TITLE
Extend feature dump

### DIFF
--- a/plugin/QaChecker.cs
+++ b/plugin/QaChecker.cs
@@ -28,7 +28,7 @@ namespace CadQaPlugin
                 .ToList();
 
             // 2 dump features
-            ExportFeatures.DumpText(
+            ExportFeatures.DumpFeatures(
                 db, tr,
                 Path.ChangeExtension(db.Filename, ".features.csv"));
 


### PR DESCRIPTION
## Summary
- rename `DumpText` to `DumpFeatures`
- expand `DumpFeatures` to include blocks, dimensions, leaders
- update call site in `QaChecker`
- output header now `Handle,ObjType,Content,Layer,Extra`

## Testing
- `dotnet build plugin/CadQaPlugin.sln -c Release` *(fails: Autodesk DLLs missing)*

------
https://chatgpt.com/codex/tasks/task_e_687eb55832fc8322b4fa2432dda1fdfb