### PR TITLE
Implement newline-safe CSV export and merging tools

### DIFF
--- a/export/ExportFeatures.cs
+++ b/export/ExportFeatures.cs
@@ -28,7 +28,7 @@ namespace CadQa.Export
                     // TEXT ---------------------------------------------------------
                     case DBText t:
                         {
-                            string txt = t.TextString;
+                            string txt = Clean(t.TextString);
                             if (IsMostlyNumeric(txt)) break;
 
                             sw.WriteLine(
@@ -38,7 +38,7 @@ namespace CadQa.Export
 
                     case MText m:
                         {
-                            string txt = m.Text;
+                            string txt = Clean(m.Text);
                             if (IsMostlyNumeric(txt)) break;
 
                             sw.WriteLine(
@@ -57,7 +57,7 @@ namespace CadQa.Export
                     // DIMENSION ----------------------------------------------------
                     case Dimension dim:
                         {
-                            string txt = dim.DimensionText?.Trim() ?? "";
+                            string txt = Clean(dim.DimensionText?.Trim());
                             if (IsMostlyNumeric(txt)) break;
 
                             sw.WriteLine(
@@ -74,7 +74,7 @@ namespace CadQa.Export
                             {
                                 var obj = tr.GetObject(l.Annotation, OpenMode.ForRead, false);
                                 if (obj is MText mAnnot)
-                                    txt = mAnnot.Text;
+                                    txt = Clean(mAnnot.Text);
                             }
 
                             if (IsMostlyNumeric(txt)) break;
@@ -86,7 +86,7 @@ namespace CadQa.Export
 
                     case MLeader ml:
                         {
-                            string txt = ml.MText?.Text ?? "";
+                            string txt = Clean(ml.MText?.Text ?? "");
                             if (IsMostlyNumeric(txt)) break;
 
                             sw.WriteLine(
@@ -108,5 +108,8 @@ namespace CadQa.Export
             }
             return digit > 0 && alpha == 0;
         }
+
+        private static string Clean(string s) =>
+            s?.Replace("\r\n", " ").Replace("\n", " ") ?? "";
     }
 }

--- a/tools/merge_csv.cmd
+++ b/tools/merge_csv.cmd
@@ -1,0 +1,6 @@
+@echo off
+powershell -NoLogo -NoProfile -ExecutionPolicy Bypass -NoExit ^
+    -File "%~dp0merge_csv.ps1"
+echo.
+echo Press any key to close . . .
+pause >nul

--- a/tools/merge_csv.ps1
+++ b/tools/merge_csv.ps1
@@ -1,0 +1,16 @@
+$ErrorActionPreference = 'Stop'
+$In  = 'C:\Users\Jesse 2025\Desktop\CAD AI\ml\artifacts\Drawings'
+$Out = 'C:\Users\Jesse 2025\Desktop\CAD AI\ml\datasets\master.csv'
+
+Write-Host "`nMerging CSVs ..."
+if (-not (Test-Path $In))  { throw "Input folder not found: $In" }
+$csvs = Get-ChildItem -Path $In -Filter '*.Text.csv'
+if ($csvs.Count -eq 0)     { throw "No *.Text.csv files in $In" }
+
+$outDir = Split-Path $Out
+if (-not (Test-Path $outDir)) { New-Item -ItemType Directory -Path $outDir | Out-Null }
+
+Get-Content $csvs[0] -First 1 | Set-Content $Out
+foreach ($f in $csvs) { Get-Content $f | Select-Object -Skip 1 | Add-Content $Out }
+
+Write-Host "`u2714 merge complete  →  $Out" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- sanitize all exported text to remove newlines
- allow spaces when prompting for batch export folder
- add merge_csv script to keep console open

## Testing
- `dotnet build -c Release` *(fails: Autodesk references missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880efc6c69c832297d20134f7c67112