### PR TITLE
Fix PowerShell training script: correct CSV pattern and move model verification to Python file

### DIFF
--- a/ml/verify_layer_model.py
+++ b/ml/verify_layer_model.py
@@ -1,0 +1,12 @@
+import os, joblib, sys, pathlib
+
+p = pathlib.Path("ml/artifacts/layer_clf.pkl")
+size = os.path.getsize(p)
+try:
+    fitted = hasattr(joblib.load(p).named_steps["tfidf"], "vocabulary_")
+except Exception:
+    fitted = False
+if size < 100_000 or not fitted:
+    print(f"Model looks unfitted (size={size}, fitted={fitted})")
+    sys.exit(1)
+print(f"Model OK  ✓  (size = {size} bytes)")


### PR DESCRIPTION
## Summary
- Correct top-of-file comment and error message to reference `*.Text.csv`
- Replace here-doc model check with standalone `ml/verify_layer_model.py`
- Invoke Python script for model verification in `full_train.ps1`

## Testing
- `python ml/verify_layer_model.py` *(fails: Model looks unfitted)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689646a77e0883229e2feb51f22f506d